### PR TITLE
Check each chunk for zero length as it comes in, this means EOF

### DIFF
--- a/asyncrcon/rcon.py
+++ b/asyncrcon/rcon.py
@@ -167,7 +167,7 @@ class AsyncRCON:
 
             while len(data) < ln:
                 try:
-                    data += await self._reader.read(ln - len(data))
+                    chunk = await self._reader.read(ln - len(data))
                 except OSError as e:
                     if not self._auto_reconnect:
                         raise e
@@ -175,9 +175,9 @@ class AsyncRCON:
                     self.close()
                     await self.open_connection()
 
-                if len(data) == 0:
+                if len(chunk) == 0:
                     raise NulLResponseException()
-
+                data += chunk
                 self._logger.debug('package {}, {}, {}'.format(data, len(data), ln))
 
     async def _send(self, packet: Packet):


### PR DESCRIPTION
I am seeing that if the remote end sends back the start of the message, but cuts off mid response (by closing the connection) then the python process goes to 100% CPU usage.

It looks like it is getting stuck because it keeps calling `.read` even though a zero length group of bytes is coming back. So I have changed it to check each chunk and bail if that happens.